### PR TITLE
dependencies: change python-igraph to igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ anndata = ">=0.7.5"
 black = {version = ">=20.8b1", optional = true}
 codecov = {version = ">=2.0.8", optional = true}
 ruff = {version = "*", optional = true}
+igraph = {version = "*", optional = true}
 importlib-metadata = {version = "^1.0", python = "<3.8"}
 ipython = {version = ">=7.1.1", optional = true}
 jupyter = {version = ">=1.0", optional = true}
@@ -44,7 +45,6 @@ ipykernel = {version = "*", optional = true}
 pytest = {version = ">=4.4", optional = true}
 pytest-cov = {version = "*", optional = true}
 python = ">=3.9,<4.0"
-python-igraph = {version = "*", optional = true}
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}
 scvelo = ">=0.2.5"


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for the explanation and consider making this change in other [YosefLab](https://github.com/YosefLab) projects as well.